### PR TITLE
Typo in TM351 VM Installation test.ipynb

### DIFF
--- a/TM351 VM Installation Test.ipynb
+++ b/TM351 VM Installation Test.ipynb
@@ -395,7 +395,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### MongDB\n",
+    "### MongoDB\n",
     "\n",
     "Test that the mongoDB database is running... This example also shows how to connect to the database."
    ]


### PR DESCRIPTION
Typo in markdown for mongoDB heading cell.